### PR TITLE
timestamp modified by PaulM to be ISO9660-like

### DIFF
--- a/zbx-backup.sh
+++ b/zbx-backup.sh
@@ -12,8 +12,8 @@
 
 VERSION="0.6.3"
 
-# Current timestamp
-TIMESTAMP=$(date +%d.%m.%Y.%H%M%S)
+# Current timestamp - modified by PaulM to be ISO9660-like
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 
 # The function just print help message
 function PrintHelpMessage() {


### PR DESCRIPTION
Using iso9660 date format means that files automatically get sorted by date.

so 20190311 is older than 20191103

whereas you can't be sure when faces with 11032019 and 03112019

